### PR TITLE
Fixed typo in loop's documentation

### DIFF
--- a/src/Bytes/Decode.elm
+++ b/src/Bytes/Decode.elm
@@ -398,12 +398,12 @@ repeated structures, like a list:
       unsignedInt32 BE
         |> andThen (\len -> loop (len, []) (listStep decoder))
 
-    listStep : Decoder a -> (Int, List a) -> Step (Int, List a) (List a)
+    listStep : Decoder a -> (Int, List a) -> Decoder (Step (Int, List a) (List a))
     listStep decoder (n, xs) =
       if n <= 0 then
         succeed (Done xs)
       else
-        map (\x -> Step (n - 1, x :: xs)) decoder
+        map (\x -> Loop (n - 1, x :: xs)) decoder
 
 The `list` decoder first reads a 32-bit unsigned integer. That determines how
 many items will be decoded. From there we use [`loop`](#loop) to track all the


### PR DESCRIPTION
Hi, I've found a couple of typos here:
1. `loop` signature said that 2nd argument should return `Decoder` back, but
`listStep` does not.
1. There is not `Step` constructor, I guess it should be `Loop` there.

And thank you for great work with files and bites!