### PR TITLE
Fix call to Kernel function (length -> width)

### DIFF
--- a/src/Bytes/Encode.elm
+++ b/src/Bytes/Encode.elm
@@ -325,7 +325,7 @@ getWidth builder =
     F64 _ _ -> 8
     Seq w _ -> w
     Utf8 w _ -> w
-    Bytes bs -> Elm.Kernel.Bytes.length bytes
+    Bytes bs -> Elm.Kernel.Bytes.width bytes
 
 
 getWidths : Int -> List Encoder -> Int


### PR DESCRIPTION
First of all, thank you for this package (and of course for Elm), I am having a lot of fun with it :)

**SSCCE**

In repl
```
> oneByte = Bytes.Encode.bytes <| Bytes.Encode.encode <| Bytes.Encode.unsignedInt8 88
Bytes (<1 bytes>) : Bytes.Encode.Encoder
> Bytes.Encode.sequence [oneByte]
ReferenceError: _Bytes_length is not defined>
```