### PR TITLE
Fix call to Kernel function (bytes -> bs)

### DIFF
--- a/src/Bytes/Encode.elm
+++ b/src/Bytes/Encode.elm
@@ -325,7 +325,7 @@ getWidth builder =
     F64 _ _ -> 8
     Seq w _ -> w
     Utf8 w _ -> w
-    Bytes bs -> Elm.Kernel.Bytes.width bytes
+    Bytes bs -> Elm.Kernel.Bytes.width bs
 
 
 getWidths : Int -> List Encoder -> Int


### PR DESCRIPTION
SSCCE

In repl

```
> b = Bytes.Encode.encode (Bytes.Encode.unsignedInt8 64)
<1 bytes> : Bytes.Bytes
> Bytes.Encode.sequence [Bytes.Encode.bytes b]
Seq NaN [Bytes (<1 bytes>)]
```
